### PR TITLE
Clears recipients before putting message in queue

### DIFF
--- a/app/code/local/Aschroder/SMTPPro/Model/Email/Template.php
+++ b/app/code/local/Aschroder/SMTPPro/Model/Email/Template.php
@@ -76,6 +76,7 @@ class Aschroder_SMTPPro_Model_Email_Template extends Mage_Core_Model_Email_Templ
 
             /** @var $emailQueue Mage_Core_Model_Email_Queue */
             $emailQueue = $this->getQueue();
+            $emailQueue->clearRecipients();
             $emailQueue->setMessageBody($text);
             $emailQueue->setMessageParameters(array(
                 'subject'           => $subject,


### PR DESCRIPTION
In recent versions of M1 (https://github.com/bragento/magento-core/blob/a1f699085c04af6ee6080d3228557edd45b0080c/app/code/core/Mage/Core/Model/Email/Template.php#L410) there's this `$emailQueue->clearRecipients();` before putting the message into the queue (I think for securty reasons). This change brings this behavior into this module.